### PR TITLE
Change docker socket location

### DIFF
--- a/docker-reg.sh
+++ b/docker-reg.sh
@@ -7,7 +7,7 @@ shift
 shift
 shift
 KV=$@
-DOCKER_PORTS=$(/usr/bin/docker port $MACH $PORT)
+DOCKER_PORTS=$(/usr/bin/docker -H unix:///docker.sock port $MACH $PORT)
 KV="host=$(echo $DOCKER_PORTS | awk -F':' '{print $1}') $KV"
 KV="port=$(echo $DOCKER_PORTS | awk -F':' '{print $2}') $KV"
 


### PR DESCRIPTION
Due to the sofflink nature of ubuntu and recent versions of docker - mounting the socet at /var/run/docker.sock doesn't work - docker cant see the host. 

As such, I've updated the command to run using the socket mounted at /docker.sock - which does work.
